### PR TITLE
Temporarily downgrade deps

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,9 +51,9 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
 		<framework src="com.google.android.gms:play-services-tagmanager:+" />
-		<framework src="com.google.firebase:firebase-core:+" />
-		<framework src="com.google.firebase:firebase-messaging:+" />
-		<framework src="com.google.firebase:firebase-config:+" />
+		<framework src="com.google.firebase:firebase-core:17.5.0" />
+		<framework src="com.google.firebase:firebase-messaging:20.2.4" />
+		<framework src="com.google.firebase:firebase-config:19.2.0" />
 		<framework src="com.google.firebase:firebase-perf:+" />
 	</platform>
 


### PR DESCRIPTION
- Temporarily downgrade deps due to incompatibility with current version of aRMT (aRMT uses deprecated methods, however this is fixed by moving to a new plugin)